### PR TITLE
Add disallowed areas

### DIFF
--- a/include/libnest2d/nester.hpp
+++ b/include/libnest2d/nester.hpp
@@ -71,6 +71,15 @@ class _Item {
     int binid_{BIN_ID_UNSET}, priority_{0};
     bool fixed_{false};
 
+    /**
+     * \brief If this is a fixed area, indicates whether it is a disallowed area
+     * or a previously placed item.
+     *
+     * If this is a disallowed area, other objects will not get packed close
+     * together with this item. It only blocks other items in its area.
+     */
+    bool disallowed_{false};
+
 public:
 
     /// The type of the shape which was handed over as the template argument.
@@ -129,10 +138,17 @@ public:
         sh_(sl::create<RawShape>(std::move(contour), std::move(holes))) {}
     
     inline bool isFixed() const noexcept { return fixed_; }
+    inline bool isDisallowedArea() const noexcept { return disallowed_; }
     inline void markAsFixedInBin(int binid)
     {
         fixed_ = binid >= 0;
         binid_ = binid;
+    }
+    inline void markAsDisallowedAreaInBin(int binid)
+    {
+        fixed_ = binid >= 0;
+        binid_ = binid;
+        disallowed_ = true;
     }
 
     inline void binId(int idx) { binid_ = idx; }

--- a/include/libnest2d/nester.hpp
+++ b/include/libnest2d/nester.hpp
@@ -143,12 +143,13 @@ public:
     {
         fixed_ = binid >= 0;
         binid_ = binid;
+        disallowed_ = false;
     }
     inline void markAsDisallowedAreaInBin(int binid)
     {
         fixed_ = binid >= 0;
         binid_ = binid;
-        disallowed_ = true;
+        disallowed_ = fixed_;
     }
 
     inline void binId(int idx) { binid_ = idx; }

--- a/include/libnest2d/placers/nfpplacer.hpp
+++ b/include/libnest2d/placers/nfpplacer.hpp
@@ -101,7 +101,7 @@ struct NfpPConfig {
      * alignment with the candidate item or do anything else.
      *
      * \param remaining A container with the remaining items waiting to be
-     * placed. You can use some features about the remaining items to alter to
+     * placed. You can use some features about the remaining items to alter the
      * score of the current placement. If you know that you have to leave place
      * for other items as well, that might influence your decision about where
      * the current candidate should be placed. E.g. imagine three big circles
@@ -735,7 +735,8 @@ private:
             remlist.insert(remlist.end(), remaining.from, remaining.to);
         }
 
-        if(items_.empty()) {
+        if(std::all_of(items_.begin(), items_.end(),
+                [](const Item& item) { return item.isDisallowedArea(); })) {
             setInitialPosition(item);
             best_overfit = overfit(item.transformedShape(), bin_);
             can_pack = best_overfit <= 0;


### PR DESCRIPTION
Hi! We've made some changes to this library to fit the needs of Cura. These changes are to fix a particular issue we've had with using the library in Cura because we seem to have a different way of dealing with the prime tower and bed clips than the application this library was originally designed for (PrusaSlicer). See also the pull request being reviewed by my colleagues: https://github.com/Ultimaker/libnest2d/pull/1

This change adds a new concept to libnest2d: Disallowed areas.

There are several places in the bin where no objects can be placed. This includes places where objects have been placed before (pre-loaded items) but also some places where there are no objects at all, but objects that should still be avoided. In Cura's case this includes the prime tower and bed clips and a few other printer-defined places. In libnest2d these are currently all "fixed" items.
The problem we faced: We want objects to group together, but we don't want to group them together with disallowed areas that are not actual printed objects. Previously placed objects and disallowed areas need to be marked as "fixed" in order to prevent the nester from moving them. However newly placed items are then still packed close together with all fixed items. In our case, we want to pack them close together with normal fixed objects, but not with non-objects such as the bed clips.

This change allows the consumer of the library to set some items to be disallowed areas. Those items are fixed, but other items won't try to pack closely together with them. In effect, just the first item doesn't need to get packed closely together since other items will then pack with the first item.

Before this change, items get placed down by the side which is a disallowed area due to the difference between nozzle positions in this case:
![image](https://user-images.githubusercontent.com/2448634/95443242-a2ecc800-095c-11eb-9638-7f25c54130e9.png)
After this change, items get placed down in the middle as the `NfpPConfig::alignment` indicates:
![image](https://user-images.githubusercontent.com/2448634/95443463-e0515580-095c-11eb-923f-dac32d4ad454.png)

I don't know if this is something you'd like to add upstream as well. Maybe it's not useful for you or not considered in scope of this library. Even if it's not useful, take it as a sign of goodwill.