### PR TITLE
fix holes duplicates while offset processing

### DIFF
--- a/include/libnest2d/backends/clipper/geometries.hpp
+++ b/include/libnest2d/backends/clipper/geometries.hpp
@@ -98,6 +98,9 @@ inline void offset(PolygonImpl& sh, TCoord<PointImpl> distance, const PolygonTag
     // Offsetting reverts the orientation and also removes the last vertex
     // so boost will not have a closed polygon.
 
+    // we plan to replace contours
+    sh.Holes.clear();
+
     bool found_the_contour = false;
     for(auto& r : result) {
         if(ClipperLib::Orientation(r)) {


### PR DESCRIPTION
Maybe I'm wrong and everything is right. But you overwrite the outer contour and add the inner ones.