### PR TITLE
CMake: Removing hardcoded install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,7 @@ export(EXPORT ${PROJECT_NAME}Targets
 install(TARGETS libnest2d libnest2d_headeronly ${LIBNAME} 
   EXPORT ${PROJECT_NAME}Targets
   RUNTIME DESTINATION bin 
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  INCLUDES DESTINATION include)
+)
 
 configure_file(cmake_modules/Config.cmake.in
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"


### PR DESCRIPTION
CMake is handling these paths quite well already.
When creating my package here it causes also extra work to place the files into the correct locations.
For example, when working with debhelper to build the packages for Debian, I normally need to set CMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) and the libs will be placed into "/usr/lib/x86_64-linux-gnu/" perfectly fine.
Removing the hardcoded locations here, will recover the functionality.