### PR TITLE
Fix CMake Error at CMakeLists.txt:125 (install)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ export(EXPORT ${PROJECT_NAME}Targets
 install(TARGETS libnest2d libnest2d_headeronly ${LIBNAME} 
   EXPORT ${PROJECT_NAME}Targets
   ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin 
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ export(EXPORT ${PROJECT_NAME}Targets
 
 install(TARGETS libnest2d libnest2d_headeronly ${LIBNAME} 
   EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin 
 )
 


### PR DESCRIPTION
When using such command:

```
cmake .. -DLIBNEST2D_HEADER_ONLY=OFF -DCMAKE_INSTALL_PREFIX=./installdir -DRP_ENABLE_DOWNLOADING=ON
```

This error is thrown:

> CMake Error at CMakeLists.txt:125 (install):
>   install TARGETS given no ARCHIVE DESTINATION for static library target
>   "libnest2d_clipper_nlopt".

This PR fixes the error, as far as tested.