### PR TITLE
CMake: Remove destination overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,13 +122,11 @@ write_basic_package_version_file(
 
 export(EXPORT ${PROJECT_NAME}Targets 
        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake" 
-       NAMESPACE ${PROJECT_NAME}::)
+       NAMESPACE ${PROJECT_NAME}::
+)
 
 install(TARGETS libnest2d libnest2d_headeronly ${LIBNAME} 
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin 
+        EXPORT ${PROJECT_NAME}Targets
 )
 
 configure_file(cmake_modules/Config.cmake.in


### PR DESCRIPTION
Having these set here just make it impossible to set other library, archive or runtime destinations relative to the root directory,

For some technical background and understanding:
I'm noticing the problem in my Debian packages, that it set the location to the library via:
"-DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu"
However, due to the previous instructions set in this file, CMake will keep trying to install the files to the hardcoded locations.
Generally in the sense of CMake this is a bad idea since we want to get and keep an OS-independent build process of our software.

Therefore, removing this stuff again :)