### PR TITLE
Avoid boost build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,11 @@ target_include_directories(libnest2d_headeronly INTERFACE $<BUILD_INTERFACE:${SR
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+# require C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_library(libnest2d INTERFACE)
 
 if(NOT LIBNEST2D_HEADER_ONLY)


### PR DESCRIPTION
The error while building *boost*:

> error: no template named 'conditional_t' in namespace 'std'; did you mean 'conditional'?

The template alias `conditional_t` is not available in C++11; it was added in C++14, as were most of the other type trait `*_t` versions. Therefore, C++14 is required to build the boost library.

![Screen Shot 2021-04-24 at 16 56 29](https://user-images.githubusercontent.com/17475482/115958785-1b446080-a51e-11eb-8325-539546addd29.png)

