### PR TITLE
[C++20] explcit cast Radians to double in comparison

### DIFF
--- a/include/libnest2d/nester.hpp
+++ b/include/libnest2d/nester.hpp
@@ -317,7 +317,7 @@ public:
 
     inline void rotation(Radians rot) BP2D_NOEXCEPT
     {
-        if(rotation_ != rot) {
+        if(static_cast<double>(rotation_) != static_cast<double>(rot)) {
             rotation_ = rot; has_rotation_ = true; tr_cache_valid_ = false;
             rmt_valid_ = false; lmb_valid_ = false;
             bb_cache_.valid = false;


### PR DESCRIPTION
While compiling a project with `-std=c++20` using gcc this error pops up:

```
libnest2d/include/libnest2d/nester.hpp:320:22: error: ambiguous overload for ‘operator!=’ (operand types are ‘libnest2d::Radians’ and ‘libnest2d::Radians’)
  320 |         if(rotation_ != rot) {
      |            ~~~~~~~~~ ^~ ~~~
      |            |            |
      |            |            libnest2d::Radians
      |            libnest2d::Radians
```

There's no `!=` operator defined for `Radians` object, therefore explicit cast to underlying `double` representation is required.

PS. I am not sure what change in C++20 standard causes this problem.